### PR TITLE
Support Laravel 13, Drop Legacy Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,38 +4,24 @@ on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
+
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        php: [8.3, 8.2, 8.1, 8.0]
-        laravel: ["^12.0", "^11.0", "^10.0", "^9.0", "^8.12"]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ["^13.0", "^12.0", "^11.0"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: ^13.0
+            testbench: 11.*
           - laravel: ^12.0
             testbench: 10.*
           - laravel: ^11.0
             testbench: 9.*
-          - laravel: ^10.0
-            testbench: 8.*
-          - laravel: ^9.0
-            testbench: 7.*
-          - laravel: ^8.12
-            testbench: ^6.23
         exclude:
-          - laravel: ^8.12
-            php: 8.3
-          - laravel: ^10.0
-            php: 8.0
-          - laravel: ^11.0
-            php: 8.0
-          - laravel: ^11.0
-            php: 8.1   
-          - laravel: ^12.0
-            php: 8.0
-          - laravel: ^12.0
-            php: 8.1   
+          - laravel: ^13.0
+            php: 8.2 
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -72,9 +58,6 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-
-      - name: Display PHP version
-        run: php -v | grep ^PHP | cut -d' ' -f2
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](https://banners.beyondco.de/Laravel%20Meta.png?theme=light&packageManager=composer+require&packageName=f9webltd%2Flaravel-meta&pattern=brickWall&style=style_1&description=Render+meta+tags+within+your+Laravel+application%2C+using+a+fluent+API&md=1&showWatermark=0&fontSize=100px&images=code)
 
+
+[![PHP ^8.2](https://img.shields.io/badge/php-%5E8.2-brightgreen)]()
 [![Packagist Version](https://img.shields.io/packagist/v/f9webltd/laravel-meta?style=flat-square)](https://packagist.org/packages/f9webltd/laravel-meta)
 [![Run Tests - Current](https://github.com/f9webltd/laravel-meta/actions/workflows/run-tests.yml/badge.svg)](https://github.com/f9webltd/laravel-meta/actions/workflows/run-tests.yml)
 [![StyleCI Status](https://github.styleci.io/repos/264978205/shield)](https://github.styleci.io/repos/264978205)
@@ -22,14 +24,14 @@ Easily render meta tags within your Laravel application, using a fluent API
 
 ## Requirements
 
-- PHP `^8.0`
-- Laravel `^8.12`, `^9.0`, `^10.0`, `^11.0` or `^12.0`
+- PHP `^8.2`
+- Laravel `^11.0`, `^12.0` or `^13.0`
 
 ### Legacy Support / Upgrading
 
-For PHP `<8.0` and Laravel `<8.12` / support, use package version [`^1.7.7`](https://github.com/f9webltd/laravel-meta/tree/1.7.7)
+For legacy support use package version [`^3.0.0`](https://github.com/f9webltd/laravel-meta/tree/3.0.0)
 
-If upgrading from `^1.0`,  see [UPGRADING](UPGRADING.md) for details.
+See [UPGRADING](UPGRADING.md) for details on breaking changes.
 
 ## Installation
 
@@ -507,6 +509,7 @@ If you discover any security related issues, please email rob@f9web.co.uk instea
 ## Credits
 
 - [Rob Allport](https://github.com/ultrono)
+- [All Contributors](https://github.com/f9webltd/laravel-meta/graphs/contributors)
 
 ## License
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## From 3.x to 4.x
+
+- Run the following command to fetch the latest package version: `composer require f9webltd/laravel-meta:^4.0`
+- The package now requires PHP `^8.2` and Laravel `^11.0` / `^12.0` or `^13.0`. Going forwards this package will actively track supported Laravel / PHP versions as per [Laravel's official support policy](https://laravel.com/docs/master/releases#support-policy)
+- No further changes are required, the API remains the same
+
 ## From 2.x to 3.x
 
 - This package now **automatically** encoded strings using `htmlentities`. This is a breaking change as already encoded strings may be passed to this package. See the [package readme](https://github.com/f9webltd/laravel-meta#quotes) for an updated usage example

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
       "role": "Developer"
     }
   ],
- "require": {
-    "php": "^8.0",
-    "illuminate/config": "^8.12|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/support": "^8.12|^9.0|^10.0|^11.0|^12.0"
-},
-"require-dev": {
-    "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
-    "phpunit/phpunit": "^9.4|^10.1|^11.5.3"
-},
+  "require": {
+    "php": "^8.2",
+    "illuminate/config": "^11.0|^12.0|^13.0",
+    "illuminate/support": "^11.0|^12.0|^13.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^9.0|^10.0|^11.0",
+    "phpunit/phpunit": "^10.5|^11.0|^12.0"
+  },
   "autoload": {
     "psr-4": {
       "F9Web\\Meta\\": "src"

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -1,16 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BladeDirectiveTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider bladeDataProvider
-     * @param  string  $expected
-     * @param  string  $directive
-     */
-    public function it_compiles_without_arguments(string $expected, string $directive)
+    #[DataProvider('bladeDataProvider')]
+    public function test_it_compiles_without_arguments(string $expected, string $directive)
     {
         $compiled = $this->app['blade.compiler']->compileString($directive);
 

--- a/tests/CanonicalTagTest.php
+++ b/tests/CanonicalTagTest.php
@@ -1,24 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CanonicalTagTest extends TestCase
 {
-    /** @test */
-    public function it_renders_the_expected_raw_tag()
+    public function test_it_renders_the_expected_raw_tag()
     {
         $this->service->set('canonical', '/users/profile/abc');
 
         $this->assertRenders('<link rel="canonical" href="/users/profile/abc" />');
     }
 
-    /**
-     * @test
-     * @dataProvider canonicalUrlsProvider
-     * @param  string  $actual
-     * @param  string  $expected
-     */
-    public function it_renders_the_expected_adjusted_tag_url(string $actual, string $expected)
+    #[DataProvider('canonicalUrlsProvider')]
+    public function test_it_renders_the_expected_adjusted_tag_url(string $actual, string $expected)
     {
         $this->app['config']->set(
             [

--- a/tests/DescriptionTagTest.php
+++ b/tests/DescriptionTagTest.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
 
 use function substr;
 
 class DescriptionTagTest extends TestCase
 {
-    /** @test */
-    public function it_renders_the_expected_description_containg_quotes()
+    public function test_it_renders_the_expected_description_containg_quotes()
     {
         $this->app['config']->set(['f9web-laravel-meta.description-limit' => null]);
 
@@ -20,8 +21,7 @@ class DescriptionTagTest extends TestCase
         $this->assertRenders('<meta name="description" content="This is a good ol&#039; SEO description"');
     }
 
-    /** @test */
-    public function it_renders_the_expected_description()
+    public function test_it_renders_the_expected_description()
     {
         $this->app['config']->set(['f9web-laravel-meta.description-limit' => null]);
 
@@ -30,8 +30,7 @@ class DescriptionTagTest extends TestCase
         $this->assertRenders('<meta name="description" content="some content"');
     }
 
-    /** @test */
-    public function it_renders_the_expected_description_using_dynamic_function_calls()
+    public function test_it_renders_the_expected_description_using_dynamic_function_calls()
     {
         $this->app['config']->set(['f9web-laravel-meta.description-limit' => null]);
 
@@ -40,8 +39,7 @@ class DescriptionTagTest extends TestCase
         $this->assertRenders('<meta name="description" content="some content"');
     }
 
-    /** @test */
-    public function it_renders_the_expected_description_when_a_limit_is_set()
+    public function test_it_renders_the_expected_description_when_a_limit_is_set()
     {
         $this->app['config']->set(['f9web-laravel-meta.description-limit' => $limit = 5]);
 

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
 
 use F9Web\Meta\Meta;
@@ -7,8 +9,7 @@ use F9Web\Meta\MetaFacade;
 
 class FacadeTest extends TestCase
 {
-    /** @test */
-    public function it_passes_calls_to_the_container(): void
+    public function test_it_passes_calls_to_the_container(): void
     {
         $this->mock(
             Meta::class,

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
 
 use F9Web\Meta\Meta;
 
 class HelperTest extends TestCase
 {
-    /** @test */
-    public function it_passes_calls_to_the_container()
+    public function test_it_passes_calls_to_the_container()
     {
         $this->mock(
             Meta::class,

--- a/tests/MacroableTest.php
+++ b/tests/MacroableTest.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
 
 use F9Web\Meta\Meta;
 
 class MacroableTest extends TestCase
 {
-    /** @test */
-    public function it_allows_macroable_methods()
+    public function test_it_allows_macroable_methods()
     {
         Meta::macro('pageNotFound', function () {
             return Meta::noIndex()
@@ -27,8 +28,7 @@ class MacroableTest extends TestCase
         $this->assertRenders('<meta property="og:title" content="the og title">');
     }
 
-    /** @test */
-    public function it_allows_for_macroable_methods_with_arguments()
+    public function test_it_allows_for_macroable_methods_with_arguments()
     {
         Meta::macro('setSomethingUnnecessarily', function ($name, $content) {
             return Meta::set($name, $content)->noIndex();
@@ -42,7 +42,6 @@ class MacroableTest extends TestCase
         $this->assertRenders('<meta name="robots" content="noindex nofollow">');
     }
 
-    /** @test */
     public function it_allows_for_macroable_methods_with_arguments_and_internal_logic()
     {
         Meta::macro('setPaginationTags', function (array $data) {

--- a/tests/MetaNameTagTest.php
+++ b/tests/MetaNameTagTest.php
@@ -1,16 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MetaNameTagTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider metaNameTagsProvider
-     * @param  string  $key
-     * @param  string  $value
-     */
-    public function it_renders_the_expected_tags(string $key, string $value)
+    #[DataProvider('metaNameTagsProvider')]
+    public function test_it_renders_the_expected_tags(string $key, string $value)
     {
         $this->service->set($key, $value);
 

--- a/tests/MetaPropertyTagTest.php
+++ b/tests/MetaPropertyTagTest.php
@@ -1,16 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MetaPropertyTagTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider metaPropertyTagsProvider
-     * @param  array  $data
-     * @param  string  $expected
-     */
-    public function it_renders_open_graph_tags(array $data, string $expected)
+    #[DataProvider('metaPropertyTagsProvider')]
+    public function test_it_renders_open_graph_tags(array $data, string $expected)
     {
         $this->service->set($data[0], $data[1]);
 

--- a/tests/MetaServiceTest.php
+++ b/tests/MetaServiceTest.php
@@ -10,8 +10,7 @@ use function implode;
 
 class MetaServiceTest extends TestCase
 {
-    /** @test */
-    public function it_renders_default_tags(): void
+    public function test_it_renders_default_tags(): void
     {
         $this->app['config']->set(
             [
@@ -34,8 +33,7 @@ class MetaServiceTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_renders_using_fluent_methods(): void
+    public function test_it_renders_using_fluent_methods(): void
     {
         $this->service
             ->favIcon('/icon.png')
@@ -87,8 +85,7 @@ class MetaServiceTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_allows_fetching_of_single_tags(): void
+    public function test_it_allows_fetching_of_single_tags(): void
     {
         $this->service::set('canonical', '/users/name');
         $this->service::set('description', 'meta description');
@@ -100,8 +97,7 @@ class MetaServiceTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_registers_and_renders_raw_tags(): void
+    public function test_it_registers_and_renders_raw_tags(): void
     {
         $this->service::setRawTag($ping = '<link rel="pingback" href="https://site.com/xmlrpc.php" />');
         $this->service::setRawTags(
@@ -118,10 +114,10 @@ class MetaServiceTest extends TestCase
         $this->assertRenders(implode(PHP_EOL, [$ping, $alternate, $next]));
     }
 
-    /** @test
+    /**
      * @throws \Exception
      */
-    public function it_can_fetch_all_tags(): void
+    public function test_it_can_fetch_all_tags(): void
     {
         $this->service
             ->set('canonical', '/users/name')
@@ -144,8 +140,7 @@ class MetaServiceTest extends TestCase
         self::assertEquals('custom', $tags['property:custom']);
     }
 
-    /** @test */
-    public function it_can_forget_tags(): void
+    public function test_it_can_forget_tags(): void
     {
         $this->service
             ->set('canonical', '/users/name')
@@ -159,8 +154,7 @@ class MetaServiceTest extends TestCase
         self::assertEmpty($this->service->tags());
     }
 
-    /** @test */
-    public function it_can_set_tags_dynamically()
+    public function test_it_can_set_tags_dynamically()
     {
         $this->service
             ->canonical('/users/create')
@@ -175,24 +169,21 @@ class MetaServiceTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_render_tags_using_the_to_html_method(): void
+    public function test_it_can_render_tags_using_the_to_html_method(): void
     {
         $this->service::set('canonical', '/users');
 
         self::assertStringContainsString('<link rel="canonical" href="/users" />', $this->service->toHtml());
     }
 
-    /** @test */
-    public function it_can_determine_tags_dynamically(): void
+    public function test_it_can_determine_tags_dynamically(): void
     {
         $this->service::set('canonical', '/users');
 
         self::assertEquals('/users', $this->service->canonical);
     }
 
-    /** @test */
-    public function it_get_all_tags_when_calling_with_parameters(): void
+    public function test_it_get_all_tags_when_calling_with_parameters(): void
     {
         $this->service::set('canonical', '/users');
         $this->service::set('title', 'meta title');
@@ -200,30 +191,26 @@ class MetaServiceTest extends TestCase
         self::assertInstanceOf(Collection::class, $this->service->get());
     }
 
-    /** @test */
-    public function it_get_all_tags_when_no_standard_tags_have_been_set(): void
+    public function test_it_get_all_tags_when_no_standard_tags_have_been_set(): void
     {
         $this->service::setRawTag('<tag />');
 
         self::assertNotEmpty($this->service->tags());
     }
 
-    /** @test */
-    public function it_gets_all_tags_when_no_raw_tags_have_been_set(): void
+    public function test_it_gets_all_tags_when_no_raw_tags_have_been_set(): void
     {
         $this->service::set('canonical', '/users');
 
         self::assertTrue(isset($this->service->tags()['canonical']));
     }
 
-    /** @test */
-    public function it_gets_all_tags_when_none_are_present(): void
+    public function test_it_gets_all_tags_when_none_are_present(): void
     {
         self::assertIsArray($this->service->tags());
     }
 
-    /** @test */
-    public function it_handles_calls_to_tags_when_no_tags_are_set(): void
+    public function test_it_handles_calls_to_tags_when_no_tags_are_set(): void
     {
         $this->service::resetTags();
 
@@ -234,8 +221,7 @@ class MetaServiceTest extends TestCase
         self::assertCount(1, $this->service->tags());
     }
 
-    /** @test */
-    public function it_handles_calls_to_tags_when_no_raw_tags_are_set(): void
+    public function test_it_handles_calls_to_tags_when_no_raw_tags_are_set(): void
     {
         $this->service::resetTags();
 
@@ -246,8 +232,7 @@ class MetaServiceTest extends TestCase
         self::assertCount(1, $this->service->tags());
     }
 
-    /** @test */
-    public function it_handles_calls_to_set_tags_when_no_tags_are_set(): void
+    public function test_it_handles_calls_to_set_tags_when_no_tags_are_set(): void
     {
         $this->service::resetTags();
 

--- a/tests/MetaServiceWhenTest.php
+++ b/tests/MetaServiceWhenTest.php
@@ -6,8 +6,7 @@ namespace F9Web\Meta\Tests;
 
 class MetaServiceWhenTest extends TestCase
 {
-    /** @test */
-    public function it_sets_tags_when_the_condition_is_true()
+    public function test_it_sets_tags_when_the_condition_is_true()
     {
         $this->service->set('description', 'hello');
 
@@ -26,8 +25,7 @@ class MetaServiceWhenTest extends TestCase
         $this->assertRenders('<meta name="robots" content="noindex nofollow">');
     }
 
-    /** @test */
-    public function it_does_not_set_tags_when_the_condition_is_false()
+    public function test_it_does_not_set_tags_when_the_condition_is_false()
     {
         $this->assertCount(0, $this->service->tags());
 
@@ -46,8 +44,7 @@ class MetaServiceWhenTest extends TestCase
         $this->assertRenders('<link rel="canonical" href="/users" />');
     }
 
-    /** @test */
-    public function it_allows_fluent_calls()
+    public function test_it_allows_fluent_calls()
     {
         $this->assertCount(0, $this->service->tags());
 

--- a/tests/MetaTitleTagTest.php
+++ b/tests/MetaTitleTagTest.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace F9Web\Meta\Tests;
 
 class MetaTitleTagTest extends TestCase
 {
-    /** @test */
-    public function it_renders_the_expected_title_containg_quotes()
+    public function test_it_renders_the_expected_title_containg_quotes()
     {
         $this->app['config']->set(['f9web-laravel-meta.description-limit' => null]);
 
@@ -18,8 +19,7 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title>This is a good ol&#039; SEO description - Meta Title Append</title>');
     }
 
-    /** @test */
-    public function it_renders_with_an_appended_title()
+    public function test_it_renders_with_an_appended_title()
     {
         $this->app['config']->set(['f9web-laravel-meta.meta-title-append' => 'AcmeLtd']);
 
@@ -28,8 +28,7 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title>Widgets, Best Widgets - AcmeLtd</title>');
     }
 
-    /** @test */
-    public function it_renders_without_an_appended_title()
+    public function test_it_renders_without_an_appended_title()
     {
         $this->app['config']->set(['f9web-laravel-meta.meta-title-append' => null]);
 
@@ -38,8 +37,7 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title>Widgets, Best Widgets</title>');
     }
 
-    /** @test */
-    public function it_renders_a_none_limited_title_length()
+    public function test_it_renders_a_none_limited_title_length()
     {
         $this->app['config']->set(
             [
@@ -55,8 +53,7 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title>abcdefghijklmnopqrstuvwxyz</title>');
     }
 
-    /** @test */
-    public function it_renders_a_limited_title_length()
+    public function test_it_renders_a_limited_title_length()
     {
         // given the title is limited to 10 characters ...
         $this->app['config']->set(
@@ -72,7 +69,6 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title>abcde</title>');
     }
 
-    /** @test */
     public function it_renders_the_default_title_when_one_is_not_set()
     {
         // given the title is not set and a default exists
@@ -87,8 +83,7 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title>App Name</title>');
     }
 
-    /** @test */
-    public function it_renders_an_empty_title_when_one_is_not_set_and_no_default_exists()
+    public function test_it_renders_an_empty_title_when_one_is_not_set_and_no_default_exists()
     {
         $this->app['config']->set(
             [
@@ -100,8 +95,7 @@ class MetaTitleTagTest extends TestCase
         $this->assertRenders('<title></title>');
     }
 
-    /** @test */
-    public function it_renders_the_expected_title_when_hyphens_are_present()
+    public function test_it_renders_the_expected_title_when_hyphens_are_present()
     {
         // given the title is not set and a default exists
         $this->app['config']->set(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,8 @@ use function resolve;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    public static $latestResponse;
+
     /** @var \F9Web\Meta\Meta */
     protected $service;
 

--- a/tests/TitleGuessorTest.php
+++ b/tests/TitleGuessorTest.php
@@ -6,6 +6,7 @@ namespace F9Web\Meta\Tests;
 
 use F9Web\Meta\Exceptions\GuessorException;
 use F9Web\Meta\TitleGuessor;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TitleGuessorTest extends TestCase
 {
@@ -25,8 +26,7 @@ class TitleGuessorTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
-    public function it_resets_class_properties()
+    public function test_it_resets_class_properties()
     {
         $service = new TitleGuessor();
         $service->withRoute('users.create');
@@ -40,8 +40,7 @@ class TitleGuessorTest extends TestCase
         $this->assertNull($service->getRoute());
     }
 
-    /** @test */
-    public function it_returns_null_when_disabled()
+    public function test_it_returns_null_when_disabled()
     {
         $this->app['config']->set(
             [
@@ -56,8 +55,7 @@ class TitleGuessorTest extends TestCase
         $this->assertNull((new TitleGuessor())->render());
     }
 
-    /** @test */
-    public function it_throws_an_exception__when_an_invalid_guessing_method_is_provided()
+    public function test_it_throws_an_exception__when_an_invalid_guessing_method_is_provided()
     {
         $this->expectException(GuessorException::class);
 
@@ -70,13 +68,8 @@ class TitleGuessorTest extends TestCase
         (new TitleGuessor())->render();
     }
 
-    /**
-     * @test
-     * @dataProvider uriSegmentsProvider
-     * @param  string  $title
-     * @param  string  $uri
-     */
-    public function it_determines_the_title_using_uri_segments(string $title, string $uri)
+    #[DataProvider('uriSegmentsProvider')]
+    public function test_it_determines_the_title_using_uri_segments(string $title, string $uri)
     {
         $this->app['config']->set(
             [
@@ -114,13 +107,8 @@ class TitleGuessorTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider  namedRoutesProvider
-     * @param  string  $title
-     * @param  string  $route
-     */
-    public function it_determines_the_title_using_named_routes(string $title, string $route)
+    #[DataProvider('namedRoutesProvider')]
+    public function test_it_determines_the_title_using_named_routes(string $title, string $route)
     {
         $this->app['config']->set(
             [


### PR DESCRIPTION
Support Laravel 13, Drop Legacy Support. 

Going forwards, the package will actively only track supported Laravel releases as per the official [Laravel Support Policy](https://laravel.com/docs/master/releases#support-policy).